### PR TITLE
Adding `@Password` Annotation

### DIFF
--- a/src/main/java/dev/joss/constraints/str/Password.java
+++ b/src/main/java/dev/joss/constraints/str/Password.java
@@ -1,0 +1,53 @@
+package dev.joss.constraints.str;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import dev.joss.constraints.str.validators.PasswordValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * The annotated element must conform to a set of commonly used password validation constraints. The
+ * OWASP and Google recommendations for password security means there are 6 configurable
+ * constraints:
+ *
+ * <ul>
+ *   <li>Mininmum Length (default 8)
+ *   <li>Maximum Length (default 64)
+ *   <li>Requires Lower Case (defaults true)
+ *   <li>Requires Upper Case (defaults true)
+ *   <li>Requires Special Characters (defaults true)
+ *   <li>Requires Numeric (defaults true)
+ * </ul>
+ *
+ * @author Joss Moffatt
+ * @since 1.0.0
+ */
+@Documented
+@Constraint(validatedBy = PasswordValidator.class)
+@Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
+@Retention(RUNTIME)
+public @interface Password {
+
+  int minLength() default 8;
+
+  int maxLength() default 64;
+
+  boolean requiresLowerCase() default true;
+
+  boolean requiresUpperCase() default true;
+
+  boolean requiresSpecialChar() default true;
+
+  boolean requiresNumeric() default true;
+
+  String message() default "{chickpea.constraints.string.Password}";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/dev/joss/constraints/str/Password.java
+++ b/src/main/java/dev/joss/constraints/str/Password.java
@@ -24,6 +24,9 @@ import java.lang.annotation.Target;
  *   <li>Requires Numeric (defaults true)
  * </ul>
  *
+ * The constraints follow logical implication. That is, if a constaint is marked as not required,
+ * but it is satisfied then it is still a valid password.
+ *
  * @author Joss Moffatt
  * @since 1.0.0
  */

--- a/src/main/java/dev/joss/constraints/str/Password.java
+++ b/src/main/java/dev/joss/constraints/str/Password.java
@@ -24,8 +24,9 @@ import java.lang.annotation.Target;
  *   <li>Requires Numeric (defaults true)
  * </ul>
  *
- * The constraints follow logical implication. That is, if a constaint is marked as not required,
- * but it is satisfied then it is still a valid password.
+ * The constraints starting with required follow logical implication. That is, if a constaint is
+ * marked as not required, but it is satisfied then it is still a valid password. The length
+ * constraints don't follow this.
  *
  * @author Joss Moffatt
  * @since 1.0.0

--- a/src/main/java/dev/joss/constraints/str/validators/PasswordValidator.java
+++ b/src/main/java/dev/joss/constraints/str/validators/PasswordValidator.java
@@ -1,0 +1,50 @@
+package dev.joss.constraints.str.validators;
+
+import static java.util.stream.Collectors.toSet;
+
+import dev.joss.constraints.str.Password;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import java.util.Set;
+import java.util.stream.IntStream;
+
+public class PasswordValidator implements ConstraintValidator<Password, String> {
+
+  private static final Set<Character> SPECIAL_CHARS =
+      " !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~".chars().mapToObj(i -> (char) i).collect(toSet());
+
+  private Password annotation;
+
+  @Override
+  public void initialize(Password constraintAnnotation) {
+    this.annotation = constraintAnnotation;
+  }
+
+  @Override
+  public boolean isValid(String value, ConstraintValidatorContext context) {
+    if (null == value) {
+      return false;
+    }
+
+    if (value.length() < annotation.minLength() || value.length() > annotation.maxLength()) {
+      return false;
+    }
+
+    IntStream passwordChars = value.chars();
+
+    // These constraints are implications converted to DNF to allow for shortcircuiting
+    boolean lowerCaseConstraint =
+        !annotation.requiresLowerCase() || passwordChars.anyMatch(Character::isLowerCase);
+    boolean upperCaseConstraint =
+        !annotation.requiresLowerCase() || passwordChars.anyMatch(Character::isUpperCase);
+    boolean specialCharsConstraint =
+        !annotation.requiresSpecialChar() || passwordChars.anyMatch(SPECIAL_CHARS::contains);
+    boolean numericConstraint =
+        !annotation.requiresNumeric() || passwordChars.anyMatch(Character::isDigit);
+
+    return lowerCaseConstraint
+        && upperCaseConstraint
+        && specialCharsConstraint
+        && numericConstraint;
+  }
+}

--- a/src/main/java/dev/joss/constraints/str/validators/PasswordValidator.java
+++ b/src/main/java/dev/joss/constraints/str/validators/PasswordValidator.java
@@ -1,17 +1,15 @@
 package dev.joss.constraints.str.validators;
 
-import static java.util.stream.Collectors.toSet;
-
 import dev.joss.constraints.str.Password;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 import java.util.Set;
-import java.util.stream.IntStream;
+import java.util.stream.Collectors;
 
 public class PasswordValidator implements ConstraintValidator<Password, String> {
 
-  private static final Set<Character> SPECIAL_CHARS =
-      " !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~".chars().mapToObj(i -> (char) i).collect(toSet());
+  private static final Set<Integer> SPECIAL_CHARS =
+      " !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~".chars().boxed().collect(Collectors.toSet());
 
   private Password annotation;
 
@@ -30,17 +28,15 @@ public class PasswordValidator implements ConstraintValidator<Password, String> 
       return false;
     }
 
-    IntStream passwordChars = value.chars();
-
     // These constraints are implications converted to DNF to allow for shortcircuiting
     boolean lowerCaseConstraint =
-        !annotation.requiresLowerCase() || passwordChars.anyMatch(Character::isLowerCase);
+        !annotation.requiresLowerCase() || value.chars().anyMatch(Character::isLowerCase);
     boolean upperCaseConstraint =
-        !annotation.requiresLowerCase() || passwordChars.anyMatch(Character::isUpperCase);
+        !annotation.requiresUpperCase() || value.chars().anyMatch(Character::isUpperCase);
     boolean specialCharsConstraint =
-        !annotation.requiresSpecialChar() || passwordChars.anyMatch(SPECIAL_CHARS::contains);
+        !annotation.requiresSpecialChar() || value.chars().anyMatch(SPECIAL_CHARS::contains);
     boolean numericConstraint =
-        !annotation.requiresNumeric() || passwordChars.anyMatch(Character::isDigit);
+        !annotation.requiresNumeric() || value.chars().anyMatch(Character::isDigit);
 
     return lowerCaseConstraint
         && upperCaseConstraint

--- a/src/test/java/dev/joss/constraints/str/IPv4Test.java
+++ b/src/test/java/dev/joss/constraints/str/IPv4Test.java
@@ -17,7 +17,7 @@ public class IPv4Test {
   public static final String incorrect = "not-an-ip";
 
   @Test
-  public void testFields() {
+  public void testAnnotatedFieldsCausesExpectedViolation() {
     IPv4BeanFields iPv4BeanFields = new IPv4BeanFields();
 
     Set<ConstraintViolation<IPv4BeanFields>> violations = validator.validate(iPv4BeanFields);
@@ -27,7 +27,7 @@ public class IPv4Test {
   }
 
   @Test
-  public void testMethods() {
+  public void testAnnotatedMethodsCausesExpectedViolation() {
     IPv4BeanMethods iPv4BeanMethods = new IPv4BeanMethods();
 
     Set<ConstraintViolation<IPv4BeanMethods>> violations = validator.validate(iPv4BeanMethods);
@@ -37,7 +37,7 @@ public class IPv4Test {
   }
 
   @Test
-  public void testType() {
+  public void testAnnotatedTypesCausesExpectedViolation() {
     IPv4BeanType iPv4BeanType = new IPv4BeanType();
 
     Set<ConstraintViolation<IPv4BeanType>> violations = validator.validate(iPv4BeanType);
@@ -47,7 +47,7 @@ public class IPv4Test {
   }
 
   @Test
-  public void testNullChecks() {
+  public void testNullBeansCausesExpectedViolation() {
     IPv4BeanNulls iPv4BeanNulls = new IPv4BeanNulls();
 
     Set<ConstraintViolation<IPv4BeanNulls>> violations = validator.validate(iPv4BeanNulls);

--- a/src/test/java/dev/joss/constraints/str/IPv6Test.java
+++ b/src/test/java/dev/joss/constraints/str/IPv6Test.java
@@ -17,7 +17,7 @@ public class IPv6Test {
   public static final String incorrect = "not-an-ip";
 
   @Test
-  public void testFields() {
+  public void testAnnotatedFieldsCausesExpectedViolation() {
     IPv6BeanFields iPv6BeanFields = new IPv6BeanFields();
 
     Set<ConstraintViolation<IPv6BeanFields>> violations = validator.validate(iPv6BeanFields);
@@ -27,7 +27,7 @@ public class IPv6Test {
   }
 
   @Test
-  public void testMethods() {
+  public void testAnnotatedMethodsCausesExpectedViolation() {
     IPv6BeanMethods iPv6BeanMethods = new IPv6BeanMethods();
 
     Set<ConstraintViolation<IPv6BeanMethods>> violations = validator.validate(iPv6BeanMethods);
@@ -37,7 +37,7 @@ public class IPv6Test {
   }
 
   @Test
-  public void testType() {
+  public void testAnnotatedTypesCausesExpectedViolation() {
     IPv6BeanType iPv6BeanType = new IPv6BeanType();
 
     Set<ConstraintViolation<IPv6BeanType>> violations = validator.validate(iPv6BeanType);
@@ -47,7 +47,7 @@ public class IPv6Test {
   }
 
   @Test
-  public void testNullChecks() {
+  public void testNullBeansCausesExpectedViolation() {
     IPv6BeanNulls iPv6BeanNulls = new IPv6BeanNulls();
 
     Set<ConstraintViolation<IPv6BeanNulls>> violations = validator.validate(iPv6BeanNulls);

--- a/src/test/java/dev/joss/constraints/str/PasswordTest.java
+++ b/src/test/java/dev/joss/constraints/str/PasswordTest.java
@@ -1,0 +1,174 @@
+package dev.joss.constraints.str;
+
+import static dev.joss.utils.ConstraintViolationSetAssert.assertThat;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import java.util.List;
+import java.util.Set;
+import lombok.Data;
+import org.junit.jupiter.api.Test;
+
+public class PasswordTest {
+
+  private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+  public static final String validPassword = "ThisPassw0rdHasAllTheConstraints!";
+  public static final String tooShortPassword = "abc";
+  public static final String tooLongPassword =
+      "this-is-a-really-really-really-really-really-really-long-password!!!!";
+  public static final String missingLowerCasePassword = "THIS_PASSW0RD_ONLY_MISSES_LOWERCASE";
+  public static final String missingUpperCasePassword = "this_passw0rd_only_misses_uppercase";
+  public static final String missingSpecialCharacterPassword = "ThisPassw0rdHasNoSpecialChars";
+  public static final String missingNumericCharacterPassword = "This_password_has_no_special_chars";
+
+  @Test
+  public void testAnnotatedFieldsCausesExpectedViolation() {
+    PasswordBeanFields passwordBeanFields = new PasswordBeanFields();
+
+    Set<ConstraintViolation<PasswordBeanFields>> violations =
+        validator.validate(passwordBeanFields);
+
+    assertThat(violations).hasSize(6);
+    assertThat(violations).containsInvalidValue(tooShortPassword);
+    assertThat(violations).containsInvalidValue(tooLongPassword);
+    assertThat(violations).containsInvalidValue(missingLowerCasePassword);
+    assertThat(violations).containsInvalidValue(missingUpperCasePassword);
+    assertThat(violations).containsInvalidValue(missingSpecialCharacterPassword);
+    assertThat(violations).containsInvalidValue(missingNumericCharacterPassword);
+  }
+
+  @Test
+  public void testRequiredConstraintsOffButStillPresentDoesntViolate() {
+    PasswordBeanConstraintsOff passwordBeanConstraintsOff = new PasswordBeanConstraintsOff();
+
+    Set<ConstraintViolation<PasswordBeanConstraintsOff>> violations =
+        validator.validate(passwordBeanConstraintsOff);
+
+    assertThat(violations).isEmpty();
+  }
+
+  @Test
+  public void testAnnotatedMethodsCausesExpectedViolation() {
+    PasswordBeanMethods passwordBeanMethods = new PasswordBeanMethods();
+
+    Set<ConstraintViolation<PasswordBeanMethods>> violations =
+        validator.validate(passwordBeanMethods);
+
+    assertThat(violations).hasSize(6);
+    assertThat(violations).containsInvalidValue(tooShortPassword);
+    assertThat(violations).containsInvalidValue(tooLongPassword);
+    assertThat(violations).containsInvalidValue(missingLowerCasePassword);
+    assertThat(violations).containsInvalidValue(missingUpperCasePassword);
+    assertThat(violations).containsInvalidValue(missingSpecialCharacterPassword);
+    assertThat(violations).containsInvalidValue(missingNumericCharacterPassword);
+  }
+
+  @Test
+  public void testAnnotatedTypesCausesExpectedViolation() {
+    PasswordBeanType passwordBeanType = new PasswordBeanType();
+
+    Set<ConstraintViolation<PasswordBeanType>> violations = validator.validate(passwordBeanType);
+
+    assertThat(violations).hasSize(6);
+    assertThat(violations).containsInvalidValue(tooShortPassword);
+    assertThat(violations).containsInvalidValue(tooLongPassword);
+    assertThat(violations).containsInvalidValue(missingLowerCasePassword);
+    assertThat(violations).containsInvalidValue(missingUpperCasePassword);
+    assertThat(violations).containsInvalidValue(missingSpecialCharacterPassword);
+    assertThat(violations).containsInvalidValue(missingNumericCharacterPassword);
+  }
+
+  @Test
+  public void testNullBeansCausesExpectedViolation() {
+    PasswordBeanNulls passwordBeanNulls = new PasswordBeanNulls();
+
+    Set<ConstraintViolation<PasswordBeanNulls>> violations = validator.validate(passwordBeanNulls);
+
+    assertThat(violations).hasSize(2);
+  }
+}
+
+@Data
+class PasswordBeanFields {
+  @Password private String correct = PasswordTest.validPassword;
+  @Password private String tooShort = PasswordTest.tooShortPassword;
+  @Password private String tooLong = PasswordTest.tooLongPassword;
+  @Password private String noLowerCase = PasswordTest.missingLowerCasePassword;
+  @Password private String noUpperCase = PasswordTest.missingUpperCasePassword;
+  @Password private String noSpecialChar = PasswordTest.missingSpecialCharacterPassword;
+  @Password private String noNumericlChar = PasswordTest.missingNumericCharacterPassword;
+}
+
+@Data
+class PasswordBeanConstraintsOff {
+  @Password(
+      requiresLowerCase = false,
+      requiresUpperCase = false,
+      requiresSpecialChar = false,
+      requiresNumeric = false)
+  private String correct = PasswordTest.validPassword;
+}
+
+@Data
+class PasswordBeanMethods {
+
+  @Password
+  private String getCorrect() {
+    return PasswordTest.validPassword;
+  }
+
+  @Password
+  private String getTooShort() {
+    return PasswordTest.tooShortPassword;
+  }
+
+  @Password
+  private String getTooLong() {
+    return PasswordTest.tooLongPassword;
+  }
+
+  @Password
+  private String getNoLowerCase() {
+    return PasswordTest.missingLowerCasePassword;
+  }
+
+  @Password
+  private String getNoUpperCase() {
+    return PasswordTest.missingUpperCasePassword;
+  }
+
+  @Password
+  private String getNoSpecialChar() {
+    return PasswordTest.missingSpecialCharacterPassword;
+  }
+
+  @Password
+  private String getNoNumericlChar() {
+    return PasswordTest.missingNumericCharacterPassword;
+  }
+}
+
+@Data
+class PasswordBeanType {
+  private List<@Password String> correct = List.of(PasswordTest.validPassword);
+  private List<@Password String> tooShort = List.of(PasswordTest.tooShortPassword);
+  private List<@Password String> tooLong = List.of(PasswordTest.tooLongPassword);
+  private List<@Password String> noLowerCase = List.of(PasswordTest.missingLowerCasePassword);
+  private List<@Password String> noUpperCase = List.of(PasswordTest.missingUpperCasePassword);
+  private List<@Password String> noSpecialChar =
+      List.of(PasswordTest.missingSpecialCharacterPassword);
+  private List<@Password String> noNumericlChar =
+      List.of(PasswordTest.missingNumericCharacterPassword);
+}
+
+@Data
+class PasswordBeanNulls {
+
+  @Password private String nullField = null;
+
+  @Password
+  private String getNullMethod() {
+    return null;
+  }
+}

--- a/src/test/java/dev/joss/utils/ConstraintViolationSetAssert.java
+++ b/src/test/java/dev/joss/utils/ConstraintViolationSetAssert.java
@@ -15,16 +15,19 @@ public class ConstraintViolationSetAssert<T>
     return new ConstraintViolationSetAssert<>(actual);
   }
 
+  public ConstraintViolationSetAssert<T> isEmpty() {
+    org.assertj.core.api.Assertions.assertThat(actual).isEmpty();
+    return this;
+  }
+
   public ConstraintViolationSetAssert<T> hasSize(int size) {
     org.assertj.core.api.Assertions.assertThat(actual).hasSize(size);
     return this;
   }
 
   public ConstraintViolationSetAssert<T> containsInvalidValue(Object invalidValue) {
-    isNotNull();
-
     for (ConstraintViolation<T> violation : actual) {
-      if (violation.getInvalidValue().equals(invalidValue)) {
+      if (violation.getInvalidValue() != null && violation.getInvalidValue().equals(invalidValue)) {
         return this;
       }
     }


### PR DESCRIPTION
Covers solution requirements in #4. 
A user can specify the length and the other required constraints for the `String` bean.