### PR TITLE
✨ Add `@CurrencyCode` constraint

### DIFF
--- a/script/create_new_annotation.py
+++ b/script/create_new_annotation.py
@@ -8,7 +8,7 @@ def create_dirs_if_non_existent(*dirs):
 annotation_name = input('🫘 Annotation name: ')
 annotation_package_offset = input('🫘 Package offset from dev.joss.chickpea.constraints (e.g. str, aws, or something new): ')
 annotation_package = f'dev.joss.chickpea.constraints.{annotation_package_offset}'
-annotation_validator_package = f'{annotation_package}.validator'
+annotation_validator_package = f'{annotation_package}.validators'
 author_name = input('🫘 Author name: ')
 
 annotation_interface = f'''package {annotation_package};
@@ -137,7 +137,7 @@ class {annotation_name}BeanType {{
 '''
 
 annotation_interface_path = f'src/main/java/{annotation_package.replace(".", "/")}'
-annotation_validator_path = f'{annotation_interface_path}/validator'
+annotation_validator_path = f'{annotation_interface_path}/validators'
 annotation_test_path = annotation_interface_path.replace('main', 'test')
 
 create_dirs_if_non_existent(annotation_interface_path, annotation_validator_path, annotation_test_path)

--- a/script/create_new_annotation.py
+++ b/script/create_new_annotation.py
@@ -144,7 +144,7 @@ create_dirs_if_non_existent(annotation_interface_path, annotation_validator_path
 
 annotation_interface_file_name = f'{annotation_name}.java'
 annotation_validator_file_name = f'{annotation_name}Validator.java'
-annotation_test_file_name = f'{annotation_name}.java'
+annotation_test_file_name = f'{annotation_name}Test.java'
 
 with open(f'{annotation_interface_path}/{annotation_interface_file_name}', 'w+') as f:
   f.writelines(annotation_interface)

--- a/src/main/java/dev/joss/chickpea/constraints/str/CurrencyCode.java
+++ b/src/main/java/dev/joss/chickpea/constraints/str/CurrencyCode.java
@@ -1,0 +1,30 @@
+package dev.joss.chickpea.constraints.str;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import dev.joss.chickpea.constraints.str.validators.CurrencyCodeValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * The annotated element must conform to the ISO-4217 format for currency codes.
+ *
+ * @see <a href="https://en.m.wikipedia.org/wiki/ISO_4217">ISO-4217 format</a>
+ * @author Joss Moffatt
+ * @since 1.0.0
+ */
+@Documented
+@Constraint(validatedBy = CurrencyCodeValidator.class)
+@Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
+@Retention(RUNTIME)
+public @interface CurrencyCode {
+  String message() default "{chickpea.constraints.string.CurrencyCode}";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/dev/joss/chickpea/constraints/str/validators/CurrencyCodeValidator.java
+++ b/src/main/java/dev/joss/chickpea/constraints/str/validators/CurrencyCodeValidator.java
@@ -1,0 +1,21 @@
+package dev.joss.chickpea.constraints.str.validators;
+
+import dev.joss.chickpea.constraints.str.CurrencyCode;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import java.util.Currency;
+import java.util.Set;
+
+public class CurrencyCodeValidator implements ConstraintValidator<CurrencyCode, String> {
+
+  @Override
+  public boolean isValid(String value, ConstraintValidatorContext context) {
+    if (value == null) {
+      return true;
+    }
+
+    Set<Currency> availableCurrencies = Currency.getAvailableCurrencies();
+    return availableCurrencies.stream()
+        .anyMatch(currency -> currency.getCurrencyCode().equalsIgnoreCase(value));
+  }
+}

--- a/src/test/java/dev/joss/chickpea/constraints/aws/ARNTest.java
+++ b/src/test/java/dev/joss/chickpea/constraints/aws/ARNTest.java
@@ -1,6 +1,6 @@
 package dev.joss.chickpea.constraints.aws;
 
-import static dev.joss.utils.ConstraintViolationSetAssert.assertThat;
+import static dev.joss.chickpea.utils.ConstraintViolationSetAssert.assertThat;
 
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validation;

--- a/src/test/java/dev/joss/chickpea/constraints/str/CurrencyCodeTest.java
+++ b/src/test/java/dev/joss/chickpea/constraints/str/CurrencyCodeTest.java
@@ -1,0 +1,83 @@
+package dev.joss.chickpea.constraints.str;
+
+import static dev.joss.chickpea.utils.ConstraintViolationSetAssert.assertThat;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import java.util.List;
+import java.util.Set;
+import lombok.Data;
+import org.junit.jupiter.api.Test;
+
+public class CurrencyCodeTest {
+
+  private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+  public static final String correct = "USD";
+  public static final String incorrect = "absldkfj23480924ljk2j34c";
+
+  @Test
+  public void testAnnotatedFieldsCausesExpectedViolation() {
+    CurrencyCodeBeanFields CurrencyCodeBeanFields = new CurrencyCodeBeanFields();
+
+    Set<ConstraintViolation<CurrencyCodeBeanFields>> violations =
+        validator.validate(CurrencyCodeBeanFields);
+
+    assertThat(violations).hasSize(1);
+    assertThat(violations).containsInvalidValue(incorrect);
+  }
+
+  @Test
+  public void testAnnotatedMethodsCausesExpectedViolation() {
+    CurrencyCodeBeanMethods CurrencyCodeBeanMethods = new CurrencyCodeBeanMethods();
+
+    Set<ConstraintViolation<CurrencyCodeBeanMethods>> violations =
+        validator.validate(CurrencyCodeBeanMethods);
+
+    assertThat(violations).hasSize(1);
+    assertThat(violations).containsInvalidValue(incorrect);
+  }
+
+  @Test
+  public void testAnnotatedTypesCausesExpectedViolation() {
+    CurrencyCodeBeanType CurrencyCodeBeanType = new CurrencyCodeBeanType();
+
+    Set<ConstraintViolation<CurrencyCodeBeanType>> violations =
+        validator.validate(CurrencyCodeBeanType);
+
+    assertThat(violations).hasSize(1);
+    assertThat(violations).containsInvalidValue(incorrect);
+  }
+
+  // TODO: These tests are merely a guideline. You should make sure the tests cover the appropriate
+  // functionality!
+}
+
+@Data
+class CurrencyCodeBeanFields {
+
+  @CurrencyCode private String correct = CurrencyCodeTest.correct;
+
+  @CurrencyCode private String incorrect = CurrencyCodeTest.incorrect;
+}
+
+@Data
+class CurrencyCodeBeanMethods {
+
+  @CurrencyCode
+  private String getCorrect() {
+    return CurrencyCodeTest.correct;
+  }
+
+  @CurrencyCode
+  private String getIncorrect() {
+    return CurrencyCodeTest.incorrect;
+  }
+}
+
+@Data
+class CurrencyCodeBeanType {
+  private List<@CurrencyCode String> correct = List.of(CurrencyCodeTest.correct);
+  private List<@CurrencyCode String> incorrect = List.of(CurrencyCodeTest.incorrect);
+}

--- a/src/test/java/dev/joss/chickpea/constraints/str/IPv4Test.java
+++ b/src/test/java/dev/joss/chickpea/constraints/str/IPv4Test.java
@@ -1,6 +1,6 @@
 package dev.joss.chickpea.constraints.str;
 
-import static dev.joss.utils.ConstraintViolationSetAssert.assertThat;
+import static dev.joss.chickpea.utils.ConstraintViolationSetAssert.assertThat;
 
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validation;

--- a/src/test/java/dev/joss/chickpea/constraints/str/IPv6Test.java
+++ b/src/test/java/dev/joss/chickpea/constraints/str/IPv6Test.java
@@ -1,6 +1,6 @@
 package dev.joss.chickpea.constraints.str;
 
-import static dev.joss.utils.ConstraintViolationSetAssert.assertThat;
+import static dev.joss.chickpea.utils.ConstraintViolationSetAssert.assertThat;
 
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validation;

--- a/src/test/java/dev/joss/chickpea/constraints/str/PasswordTest.java
+++ b/src/test/java/dev/joss/chickpea/constraints/str/PasswordTest.java
@@ -1,6 +1,6 @@
 package dev.joss.chickpea.constraints.str;
 
-import static dev.joss.utils.ConstraintViolationSetAssert.assertThat;
+import static dev.joss.chickpea.utils.ConstraintViolationSetAssert.assertThat;
 
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validation;

--- a/src/test/java/dev/joss/chickpea/utils/ConstraintViolationSetAssert.java
+++ b/src/test/java/dev/joss/chickpea/utils/ConstraintViolationSetAssert.java
@@ -1,4 +1,4 @@
-package dev.joss.utils;
+package dev.joss.chickpea.utils;
 
 import jakarta.validation.ConstraintViolation;
 import java.util.Set;


### PR DESCRIPTION
# Description

Added the changes for the `@CurrencyCode`. Using the `java.utils.Constraint` library to get all currency codes under the ISO-4217 spec.

Fixes #13

## Type of change

Please tick options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules